### PR TITLE
Fix movie handling logic

### DIFF
--- a/src/rpy_motion_detector/motion_detector.py
+++ b/src/rpy_motion_detector/motion_detector.py
@@ -247,7 +247,7 @@ class MotionDetector:
             )
 
     def record_precapture_frames(self, frame_buffer: list, movie_filename: str):
-        logger.info("Recording pre-capture frames to %s", {movie_filename})
+        logger.info("Recording pre-capture frames to %s", movie_filename)
         gst_str = (
             f"appsrc ! "
             f"videoconvert ! "
@@ -403,10 +403,10 @@ class MotionDetector:
                 precapture_movie_filename, movie_filename, final_movie_name
             )
             if success:
+                logger.info(f"Movies concatenated successfully: {final_movie_name}")
+            else:
                 logger.error(f"Error concatenating movies: {error_message}")
                 final_movie_name = movie_filename
-            else:
-                logger.info(f"Movies concatenated successfully: {final_movie_name}")
         # Run the movie end command
         completed = subprocess.run(
             self.config.event.on_movie_end.format(filename=final_movie_name),
@@ -443,7 +443,7 @@ class MotionDetector:
                         self.final_movie_filename,
                     ),
                 ).start()
-                self.precapture_movie_filename = (None,)
+                self.precapture_movie_filename = None
                 self.movie_filename = None
                 self.final_movie_filename = None
             except Exception as e:


### PR DESCRIPTION
## Summary
- fix logging when recording precapture frames
- fix concatenation success check
- reset `precapture_movie_filename` correctly

## Testing
- `python -m py_compile src/*/*.py`
- `PYTHONPATH=src python -m rpy_motion_detector.run --dry-run --config config/default.ini` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_687a64d1e6fc8325a0cb62d618ba5f69