### PR TITLE
Add exclusion zones for motion detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Key Configuration Options:
     - `bin_threshold`: Binary conversion threshold. Pixel above value are set to white (detected).
     - `min_area`: Minimum area (in pixels) of motion required to trigger detection. Helps filter out small, irrelevant movements.
     - `blur_size`: Size of the Gaussian blur applied to frames to reduce noise and improve detection accuracy.
-    - `exclude_zones`: Optional list of zones to ignore. Format: `x1,y1,x2,y2;x1,y1,x2,y2`.
+    - `exclude_zones`: Optional list of zones to ignore. Format: `x1,y1,x2,y2;x1,y1,x2,y2`. Each tuple must satisfy `x1 < x2` and `y1 < y2`.
 - Movie Settings
     - `dirpath`: Directory where recorded videos will be saved.
     - `precapture_seconds`: Number of seconds to include in the video before motion is detected.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Key Configuration Options:
     - `bin_threshold`: Binary conversion threshold. Pixel above value are set to white (detected).
     - `min_area`: Minimum area (in pixels) of motion required to trigger detection. Helps filter out small, irrelevant movements.
     - `blur_size`: Size of the Gaussian blur applied to frames to reduce noise and improve detection accuracy.
+    - `exclude_zones`: Optional list of zones to ignore. Format: `x1,y1,x2,y2;x1,y1,x2,y2`.
 - Movie Settings
     - `dirpath`: Directory where recorded videos will be saved.
     - `precapture_seconds`: Number of seconds to include in the video before motion is detected.

--- a/config/default.ini
+++ b/config/default.ini
@@ -10,6 +10,7 @@ blur_size = 21
 background_substractor_history = 500
 dilation_iterations = 2
 consecutive_frames = 3
+# Format: x1,y1,x2,y2;x1,y1,x2,y2 (x1 < x2, y1 < y2)
 exclude_zones =
 
 [movie]

--- a/config/default.ini
+++ b/config/default.ini
@@ -10,6 +10,7 @@ blur_size = 21
 background_substractor_history = 500
 dilation_iterations = 2
 consecutive_frames = 3
+exclude_zones =
 
 [movie]
 enable = true

--- a/src/rpy_motion_detector/config.py
+++ b/src/rpy_motion_detector/config.py
@@ -120,7 +120,8 @@ class MotionDetectorConfig:
     def parse_exclude_zones(value: str) -> List[Tuple[int, int, int, int]]:
         """Parse the exclude_zones string from the config file.
 
-        The expected format is "x1,y1,x2,y2;x1,y1,x2,y2".
+        The expected format is "x1,y1,x2,y2;x1,y1,x2,y2" with `x1 < x2` and
+        `y1 < y2` for each tuple. Invalid tuples are ignored.
         Returns a list of tuples (x1, y1, x2, y2).
         """
         zones: List[Tuple[int, int, int, int]] = []
@@ -132,8 +133,11 @@ class MotionDetectorConfig:
                 continue
             try:
                 x1, y1, x2, y2 = map(int, parts)
-                zones.append((x1, y1, x2, y2))
             except ValueError:
                 # Skip malformed zone specification
                 continue
+            if x1 >= x2 or y1 >= y2:
+                # Invalid zone geometry
+                continue
+            zones.append((x1, y1, x2, y2))
         return zones

--- a/src/rpy_motion_detector/config.py
+++ b/src/rpy_motion_detector/config.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import List, Tuple
 import configparser
 
 
@@ -22,6 +23,7 @@ class DetectionConfig:
     blur_size: int = 21
     dilate_iterations: int = 2
     consecutive_frames: int = 3  # number of frames to consider motion detected
+    exclude_zones: list | None = None
 
 
 @dataclass
@@ -81,7 +83,10 @@ class MotionDetectorConfig:
                 'detection', 'background_substractor_history', fallback=500),
             blur_size=config.getint('detection', 'blur_size', fallback=21),
             dilate_iterations=config.getint('detection', 'dilate_iterations', fallback=2),
-            consecutive_frames=config.getint('detection', 'consecutive_frames', fallback=3)
+            consecutive_frames=config.getint('detection', 'consecutive_frames', fallback=3),
+            exclude_zones=self.parse_exclude_zones(
+                config.get('detection', 'exclude_zones', fallback='')
+            ),
         )
         self.movie = MovieConfig(
             enable=config.getboolean('movie', 'enable', fallback=True),
@@ -110,3 +115,25 @@ class MotionDetectorConfig:
         self.tmp_dir = TmpDirConfig(
             dirpath=config.get('tmp', 'dirpath', fallback='/tmp')
         )
+
+    @staticmethod
+    def parse_exclude_zones(value: str) -> List[Tuple[int, int, int, int]]:
+        """Parse the exclude_zones string from the config file.
+
+        The expected format is "x1,y1,x2,y2;x1,y1,x2,y2".
+        Returns a list of tuples (x1, y1, x2, y2).
+        """
+        zones: List[Tuple[int, int, int, int]] = []
+        if not value:
+            return zones
+        for zone in value.split(';'):
+            parts = [p.strip() for p in zone.split(',') if p.strip()]
+            if len(parts) != 4:
+                continue
+            try:
+                x1, y1, x2, y2 = map(int, parts)
+                zones.append((x1, y1, x2, y2))
+            except ValueError:
+                # Skip malformed zone specification
+                continue
+        return zones

--- a/src/rpy_motion_detector/config.py
+++ b/src/rpy_motion_detector/config.py
@@ -24,7 +24,7 @@ class DetectionConfig:
     blur_size: int = 21
     dilate_iterations: int = 2
     consecutive_frames: int = 3  # number of frames to consider motion detected
-    exclude_zones: list | None = None
+    exclude_zones: List[Tuple[int, int, int, int]] | None = None
 
 
 @dataclass

--- a/src/rpy_motion_detector/config.py
+++ b/src/rpy_motion_detector/config.py
@@ -24,7 +24,7 @@ class DetectionConfig:
     blur_size: int = 21
     dilate_iterations: int = 2
     consecutive_frames: int = 3  # number of frames to consider motion detected
-    exclude_zones: List[Tuple[int, int, int, int]] | None = None
+    exclude_zones: Optional[List[Tuple[int, int, int, int]]] = None
 
 
 @dataclass

--- a/src/rpy_motion_detector/frame_detection.py
+++ b/src/rpy_motion_detector/frame_detection.py
@@ -21,7 +21,17 @@ def frame_processing(frame, blur_size, substractor, bin_threshold, dilate_iterat
     return dilated
 
 
-def find_contours(processed_frame, min_area, max_area, exclude_zones=None):
+def is_intersecting(rect1: tuple[int, int, int, int], rect2: tuple[int, int, int, int]) -> bool:
+    """
+    Check if two rectangles intersect.
+    rect1 and rect2 are tuples (x1, y1, x2, y2).
+    """
+    x11, y11, x12, y12 = rect1
+    x21, y21, x22, y22 = rect2
+    return (x11 < x22 and x21 < x12 and y11 < y22 and y21 < y12)
+
+
+def find_contours(processed_frame, min_area, max_area, exclude_zones: list[tuple[int, int, int, int]] = None):
     # Find contours
     contours, _ = cv2.findContours(
         processed_frame, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
@@ -35,8 +45,8 @@ def find_contours(processed_frame, min_area, max_area, exclude_zones=None):
         if min_area < area < max_area:
             x, y, w, h = cv2.boundingRect(contour)
             intersect = False
-            for zx1, zy1, zx2, zy2 in exclude_zones:
-                if x < zx2 and x + w > zx1 and y < zy2 and y + h > zy1:
+            for exclude_zone in exclude_zones:
+                if is_intersecting((x, y, x + w, y + h), exclude_zone):
                     intersect = True
                     break
             if not intersect:

--- a/src/rpy_motion_detector/frame_detection.py
+++ b/src/rpy_motion_detector/frame_detection.py
@@ -21,17 +21,26 @@ def frame_processing(frame, blur_size, substractor, bin_threshold, dilate_iterat
     return dilated
 
 
-def find_contours(processed_frame, min_area, max_area):
+def find_contours(processed_frame, min_area, max_area, exclude_zones=None):
     # Find contours
     contours, _ = cv2.findContours(
         processed_frame, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
     )
     matching_contours = []
+    if exclude_zones is None:
+        exclude_zones = []
     for contour in contours:
         # Calculate the area of each contour
         area = cv2.contourArea(contour)
         if min_area < area < max_area:
-            matching_contours.append(contour)
+            x, y, w, h = cv2.boundingRect(contour)
+            intersect = False
+            for zx1, zy1, zx2, zy2 in exclude_zones:
+                if x < zx2 and x + w > zx1 and y < zy2 and y + h > zy1:
+                    intersect = True
+                    break
+            if not intersect:
+                matching_contours.append(contour)
     return matching_contours
 
 

--- a/src/rpy_motion_detector/motion_detector.py
+++ b/src/rpy_motion_detector/motion_detector.py
@@ -146,6 +146,7 @@ class MotionDetector:
             processed_frame,
             min_area=self.config.detection.min_area,
             max_area=self.config.detection.max_area,
+            exclude_zones=self.config.detection.exclude_zones,
         )
         # detect motion after a soak time period
         if time.time() - self.start_time > 10:


### PR DESCRIPTION
## Summary
- support `exclude_zones` in detection configuration
- filter contours intersecting excluded zones
- update default config and docs

## Testing
- `python -m compileall -q src`

------
https://chatgpt.com/codex/tasks/task_e_687a6543fd5c8325843c27988575f7bd